### PR TITLE
A Suggestion

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -75,9 +75,12 @@ logM :: String -> EvalM ()
 logM s = liftIO $ do time <- getCurrentTime
                      putStrLn $ show time ++ ": " ++ s
 
-restCallTrace :: HasCallStack => (FromJSON a, Request (r a)) => r a -> EvalM (Either RestCallException a)
-restCallTrace req = do bot <- use botHandle >>= liftIO . readMVar
-                       resp <- liftIO $ restCall bot req
+sendRest :: HasCallStack => (FromJSON a, Request (r a)) => r a -> EvalM (Either RestCallException a)
+sendRest req = do bot <- use botHandle >>= liftIO . readMVar
+                  liftIO $ restCall bot req
+
+sendRestTrace :: HasCallStack => (FromJSON a, Request (r a)) => r a -> EvalM (Either RestCallException a)
+sendRestTrace req = do resp <- sendRest req
                        case resp of
                          Left err -> do logM "Error while calling REST:"
                                         logM (show err)

--- a/Main.hs
+++ b/Main.hs
@@ -118,7 +118,6 @@ eventLoop = do bot <- use botHandle >>= liftIO . readMVar
                                    eventLoop
                  Left err -> do logM "Exception in nextEvent:"
                                 logM (show err)
-                                liftIO $ threadDelay $ 10 * 10^6
 
 parseMode :: Text -> Mode
 parseMode t = case T.toLower t of

--- a/Main.hs
+++ b/Main.hs
@@ -39,6 +39,7 @@ import DupQueue
 
 getAuth :: IO Auth
 getAuth = Auth <$> read <$> readFile "auth.conf"
+login = loginRest =<< getAuth
 
 prune_messages_after_seconds = 10 * 60
 max_blocks_per_msg = 10

--- a/Main.hs
+++ b/Main.hs
@@ -102,9 +102,9 @@ frontLoop :: EvalM ()
 frontLoop = forever $ catch (do bot <- liftIO $ loginRestGateway =<< getAuth
                                 void $ finally (do use botHandle >>= \h -> liftIO $ putMVar h bot
                                                    logM "Connected"
-                                                   eventLoop
-                                                   use botHandle >>= \h -> liftIO $ takeMVar h)
-                                               (do logM "Disconnected"
+                                                   eventLoop)
+                                               (do use botHandle >>= \h -> liftIO $ takeMVar h
+                                                   logM "Disconnected"
                                                    liftIO $ stopDiscord bot))
                             (\e -> do logM "Exception in mainLoop:"
                                       logM (show (e :: SomeException))

--- a/discord-eval.cabal
+++ b/discord-eval.cabal
@@ -16,7 +16,7 @@ executable discord-eval
   main-is:             Main.hs
   other-modules:       DupQueue
   build-depends:       base == 4.*,
-                       discord-haskell,
+                       discord-haskell == 0.7.1,
                        containers,
                        transformers,
                        mtl,


### PR DESCRIPTION
This pull request pins down discord-haskell to the most recent version (0.7.1) in the cabal file.

All the discord commands are thread safe, so you can call `restCall`, `nextEvent`, etc from multiple threads at the same time. Internally they read and write using [Control.Concurrent.Chan](https://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Concurrent-Chan.html).

The library should be pretty stable.

From `restCall` (`RestCallException`) you will commonly see `RestCallErrorCode` responses. `RestCallHttpException` will appear when your internet connection drops.

From `nextEvent` (`GatewayException`) you will see `GatewayExceptionCouldNotConnect` when the internet drops and on invalid Authentication. You should never see anything else.

I have a long-term goal to reduce this mixing of expected/unexpected errors with version 1.0.0 along with some other library restructuring.

Please open an issue on discord-haskell if anything unexpectedly breaks.
