### PR TITLE
Use v0.7.1 and threadsafe restCall

### DIFF
--- a/discord-eval.cabal
+++ b/discord-eval.cabal
@@ -16,7 +16,7 @@ executable discord-eval
   main-is:             Main.hs
   other-modules:       DupQueue
   build-depends:       base == 4.*,
-                       discord-haskell,
+                       discord-haskell == 0.7.1,
                        containers,
                        transformers,
                        mtl,


### PR DESCRIPTION
Specify the exact `discord-haskell` version because even non-breaking changes are bug-fixes.

It is not necessary to use bracket resource acquisition because `restCall` is threadsafe. `restCall` is defined as [Discord.Rest.writeRestCall](https://github.com/aquarial/discord-haskell/blob/master/src/Discord.hs#L77) which [pushes an MVar onto a Chan](https://github.com/aquarial/discord-haskell/blob/master/src/Discord/Rest.hs#L36) for single background thread to handle.

