### PR TITLE
Sort outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.dyn_hi
 *.dyn_o
 eval.conf
+dist-newstyle/

--- a/Format.hs
+++ b/Format.hs
@@ -49,4 +49,4 @@ formatResults maxChars results = go [] $
         link <- pastebin result
         go ((i, formatPaste link):pasted) bs
       | otherwise
-      = pure $ T.concat $ snd <$> (sortOn fst pasted ++ (second snd <$> blocks))
+      = pure $ T.concat $ snd <$> (sortOn fst $ pasted ++ (second snd <$> blocks))


### PR DESCRIPTION
Sort outputs based on the order they come in, instead of just in length order

Also hides dist-newstyle